### PR TITLE
Possible Update to KSP 1.5.1?

### DIFF
--- a/GameData/ContractPacks/HistoricalProgression/HistoricalProgression.version
+++ b/GameData/ContractPacks/HistoricalProgression/HistoricalProgression.version
@@ -13,19 +13,19 @@
 	"KSP_VERSION":
 	{
 		"MAJOR":1,
-		"MINOR":2,
-		"PATCH":2
+		"MINOR":5,
+		"PATCH":1
 	},
 	"KSP_VERSION_MIN":
 	{
 		"MAJOR":1,
-		"MINOR":2,
-		"PATCH":0
+		"MINOR":5,
+		"PATCH":1
 	},
 	"KSP_VERSION_MAX":
 	{
 		"MAJOR":1,
-		"MINOR":2,
+		"MINOR":5,
 		"PATCH":99
 	}
 }

--- a/GameData/ContractPacks/HistoricalProgression/HistoricalProgression.version
+++ b/GameData/ContractPacks/HistoricalProgression/HistoricalProgression.version
@@ -7,7 +7,7 @@
 	{
 		"MAJOR":1,
 		"MINOR":6,
-		"PATCH":0,
+		"PATCH":1,
 		"BUILD":0
 	},
 	"KSP_VERSION":

--- a/GameData/ContractPacks/HistoricalProgression/Missions.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions.cfg
@@ -36,6 +36,7 @@ CONTRACT_GROUP
 		name = ApolloProgram
 		displayName = Apollo Program
 		agent = Apollo Program
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 6
@@ -46,6 +47,7 @@ CONTRACT_GROUP
 		name = Apollo-Soyuz
 		displayName = Apollo Soyuz Test Project
 		agent = Apollo Soyuz Test Project
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 8
@@ -55,6 +57,7 @@ CONTRACT_GROUP
 		name = ESAMissions
 		displayName = European Space Agency Contracts
 		agent = ESA
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 11
@@ -65,6 +68,7 @@ CONTRACT_GROUP
 		name = ISS
 		displayName = International Space Station
 		agent = International Space Station
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 13
@@ -74,6 +78,7 @@ CONTRACT_GROUP
 		name = JAXAMissions
 		displayName = JAXA Contracts
 		agent = JAXA
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 12
@@ -83,6 +88,7 @@ CONTRACT_GROUP
 		name = Mir
 		displayName = Mir Space Station
 		agent = Mir
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 10
@@ -92,6 +98,7 @@ CONTRACT_GROUP
 		name = NASAMissions
 		displayName = NASA Contracts
 		agent = NASA
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 4
@@ -101,6 +108,7 @@ CONTRACT_GROUP
 		name = Peenemunde
 		displayName = Early Peenemunde Rocketry
 		agent = Peenemunde Army Research Center
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 1
@@ -110,6 +118,7 @@ CONTRACT_GROUP
 		name = ProjectGemini
 		displayName = Project Gemini
 		agent = Project Gemini
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 5
@@ -119,6 +128,7 @@ CONTRACT_GROUP
 		name = ShuttleMissions
 		displayName = Space Shuttle Missions
 		agent = NASA Space Transportation System
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 9
@@ -128,6 +138,7 @@ CONTRACT_GROUP
 		name = Skylab
 		displayName = Skylab Space Station
 		agent = Skylab
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 7
@@ -137,6 +148,7 @@ CONTRACT_GROUP
 		name = USMissions
 		displayName = Early US Missions
 		agent = USA
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 3
@@ -146,6 +158,7 @@ CONTRACT_GROUP
 		name = USSRMissions
 		displayName = Soviet Space Program
 		agent = USSR
+		minVersion = 1.16.0
 		maxSimultaneous = 10
 		maxCompletions = 0
 		sortKey = 2

--- a/GameData/ContractPacks/HistoricalProgression/Missions/1960Missions.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/1960Missions.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 
 	cancellable = false
 	declinable = false
@@ -112,7 +111,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -213,7 +211,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 
 	cancellable = false
 	declinable = false
@@ -312,7 +309,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 
 	cancellable = false
 	declinable = false
@@ -402,7 +398,6 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
 
 	cancellable = true
 	declinable = true
@@ -491,7 +486,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -591,7 +585,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -670,7 +663,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 
 	cancellable = false
 	declinable = false
@@ -779,7 +771,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -870,7 +861,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -962,7 +952,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 
 	cancellable = false
 	declinable = false
@@ -1062,7 +1051,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -1167,7 +1155,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/1970Missions.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/1970Missions.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -129,7 +128,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -341,7 +339,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/1990Missions.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/1990Missions.cfg
@@ -22,7 +22,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -99,7 +98,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -295,7 +293,7 @@ CONTRACT_TYPE
 			type = ReachState
 			targetBody = @/titan
 			situation = LANDED
-			sitaution = SPLASHED
+			situation = SPLASHED
 			disableOnStateChange = true
 			title = Land on @/titan
 

--- a/GameData/ContractPacks/HistoricalProgression/Missions/2000Missions.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/2000Missions.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 
 	cancellable = false
 	declinable = false
@@ -163,7 +162,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -268,7 +266,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -485,7 +482,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -621,7 +617,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/ApolloProgram.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/ApolloProgram.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -163,7 +162,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -299,7 +297,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -445,7 +442,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -588,7 +584,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -732,7 +727,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -962,7 +956,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -1192,7 +1185,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/EarlyMissions.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/EarlyMissions.cfg
@@ -30,7 +30,6 @@ CONTRACT_TYPE
 	minExpiry = 0
     maxExpiry = 0
     maxCompletions = 1
-	weight = 999
 	
     cancellable = false
     declinable = false
@@ -110,7 +109,6 @@ CONTRACT_TYPE
     minExpiry = 0
     maxExpiry = 0
     maxCompletions = 1
-	weight = 999
 	
     cancellable = false
     declinable = false
@@ -190,7 +188,6 @@ CONTRACT_TYPE
     minExpiry = 0
     maxExpiry = 0
     maxCompletions = 1
-	weight = 999
 	
     cancellable = false
     declinable = false
@@ -272,7 +269,6 @@ CONTRACT_TYPE
     minExpiry = 0
     maxExpiry = 0
     maxCompletions = 1
-	weight = 999
 	
     cancellable = false
     declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/JupiterExploration.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/JupiterExploration.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -115,7 +114,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -254,7 +252,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -456,7 +453,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -638,7 +634,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -807,7 +802,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/MarsExploration.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/MarsExploration.cfg
@@ -25,7 +25,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -120,7 +119,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -214,7 +212,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -310,7 +307,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -397,7 +393,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/MoonExploration.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/MoonExploration.cfg
@@ -36,7 +36,6 @@ CONTRACT_TYPE
     minExpiry = 0
     maxExpiry = 0
     maxCompletions = 1
-	weight = 999
 	
     cancellable = false
     declinable = false
@@ -127,7 +126,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -268,7 +266,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 
 	cancellable = false
 	declinable = false
@@ -373,7 +370,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -464,7 +460,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -554,7 +549,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -652,7 +646,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 
 	cancellable = false
 	declinable = false
@@ -752,7 +745,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/Observatories.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/Observatories.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -108,7 +107,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -196,7 +194,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -285,7 +282,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -374,7 +370,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -463,7 +458,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -568,7 +562,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -657,7 +650,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/OptionalMissions/MarsOptional.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/OptionalMissions/MarsOptional.cfg
@@ -20,8 +20,7 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = true
 	declinable = true
 	

--- a/GameData/ContractPacks/HistoricalProgression/Missions/OptionalMissions/MirOptional.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/OptionalMissions/MirOptional.cfg
@@ -20,8 +20,7 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = true
 	declinable = true
 	
@@ -125,8 +124,7 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = true
 	declinable = true
 	
@@ -257,8 +255,7 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = true
 	declinable = true
 	
@@ -416,8 +413,7 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = true
 	declinable = true
 	
@@ -520,8 +516,7 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = false
 	declinable = false
 	
@@ -658,8 +653,7 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = true
 	declinable = true
 	
@@ -769,8 +763,7 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = true
 	declinable = true
 	
@@ -856,8 +849,7 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = true
 	declinable = true
 	
@@ -1024,8 +1016,7 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
-	
+		
 	cancellable = true
 	declinable = true
 	

--- a/GameData/ContractPacks/HistoricalProgression/Missions/OptionalMissions/MoonOptional.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/OptionalMissions/MoonOptional.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = true
 	declinable = true
@@ -111,7 +110,6 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = true
 	declinable = true
@@ -209,7 +207,6 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = true
 	declinable = true
@@ -300,7 +297,6 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = true
 	declinable = true
@@ -391,7 +387,6 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = true
 	declinable = true
@@ -482,7 +477,6 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = true
 	declinable = true
@@ -580,7 +574,6 @@ CONTRACT_TYPE
 	minExpiry = 1
 	maxExpiry = 7
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = true
 	declinable = true

--- a/GameData/ContractPacks/HistoricalProgression/Missions/OptionalMissions/SatellitesOptional.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/OptionalMissions/SatellitesOptional.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
     minExpiry = 0
     maxExpiry = 0
     maxCompletions = 1
-	weight = 999
 	
     cancellable = true
     declinable = true
@@ -95,7 +94,6 @@ CONTRACT_TYPE
     minExpiry = 0
     maxExpiry = 0
     maxCompletions = 1
-	weight = 999
 	
     cancellable = true
     declinable = true
@@ -178,7 +176,6 @@ CONTRACT_TYPE
     minExpiry = 0
     maxExpiry = 0
     maxCompletions = 1
-	weight = 999
 	
     cancellable = true
     declinable = true

--- a/GameData/ContractPacks/HistoricalProgression/Missions/ProjectGemini.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/ProjectGemini.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -128,7 +127,6 @@ CONTRACT_TYPE
     minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -264,7 +262,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/ShuttleMissions.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/ShuttleMissions.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -145,7 +144,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -339,7 +337,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -532,7 +529,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -669,7 +665,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -775,7 +770,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -914,7 +908,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/SpaceStations.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/SpaceStations.cfg
@@ -20,7 +20,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -247,7 +246,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -476,7 +474,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -642,7 +639,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -808,7 +804,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -1041,7 +1036,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -1138,7 +1132,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -1304,7 +1297,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -1437,7 +1429,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -1526,7 +1517,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -1623,7 +1613,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -1788,7 +1777,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/GameData/ContractPacks/HistoricalProgression/Missions/VenusExploration.cfg
+++ b/GameData/ContractPacks/HistoricalProgression/Missions/VenusExploration.cfg
@@ -25,7 +25,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -105,7 +104,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -193,7 +191,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -338,7 +335,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -426,7 +422,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -540,7 +535,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -637,7 +631,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -735,7 +728,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false
@@ -823,7 +815,6 @@ CONTRACT_TYPE
 	minExpiry = 0
 	maxExpiry = 0
 	maxCompletions = 1
-	weight = 999
 	
 	cancellable = false
 	declinable = false

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ CC-BY-NC-SA (http://creativecommons.org/licenses/by-nc-sa/4.0/)
 * Removed "weight" variable (deprecated)
 * Fix typo in Cassini Mission
 * Bumped Contract Configurator version requirement to 1.16
+The above changes will let it load in KSP 1.5.1 and CC 1.26 without throwing warnings
 
 1.6 - April 24, 2017
 * Small fixes to many missions to fix completion issues

--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ CC-BY-NC-SA (http://creativecommons.org/licenses/by-nc-sa/4.0/)
 
 **CHANGELOG**
 
+1.61 - December 7, 2018 - Changes by -D-
+* Removed "weight" variable (deprecated)
+* Fix typo in Cassini Mission
+* Bumped Contract Configurator version requirement to 1.16
+
 1.6 - April 24, 2017
 * Small fixes to many missions to fix completion issues
 * Fix to STS-41B by removing the EVA as it was not working correctly

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ CC-BY-NC-SA (http://creativecommons.org/licenses/by-nc-sa/4.0/)
 * Small fixes to many missions to fix completion issues
 * Fix to STS-41B by removing the EVA as it was not working correctly
 * Fix Apollo Rover missions by allowing player to accopmlish mission using a separate craft from lander
+* These fixes will only enable loading into KSP 1.51 with CC 1.26 without dropping warnings in the log or CC debug
 
 1.5 - March 6, 2017
 * Fixed secondary Apoapsis in Apollo 4 to make it be on the correct side of the Mun in stock sizes!


### PR DESCRIPTION
Hello;

I *think* I updated this to comply with KSP 1.51 and CC 1.26. I simply corrected the source of warnings in the KSP.log and in the CC debug window:
I removed the weight variable from all files as it flagged a deprecated warning.
I bumped the Min CC required version to 1.16, as it flagged a warning about not giving all the warnings because it was originally set below 1.15
I found a typo in the Cassini mission, situation was spelled "sitaution", causing a warning.

This will load on my KSP with no warnings from KSP or CC. I cannot vouch that all the missions will work as intended as I am a horrible rocket pilot. 

Thank you for your time. I will make a post in the forum thread to advise you as well (I've never used Github, so I'm not exactly sure how all of this works or if I'm doing it right)